### PR TITLE
Fix the warning

### DIFF
--- a/msbuild-api-docs/xml/Microsoft.Build.Construction/ProjectRootElement.xml
+++ b/msbuild-api-docs/xml/Microsoft.Build.Construction/ProjectRootElement.xml
@@ -2831,7 +2831,7 @@ The caller must add the UsingTask element to the location of choice in the proje
         <summary>
              Reload the existing project root element from the given <paramref name="reader" />
              A reload operation completely replaces the state of this <see cref="T:Microsoft.Build.Construction.ProjectRootElement" /> object. This operation marks the
-             object as dirty (see <see cref="M:Microsoft.Build.Construction.ProjectRootElement.MarkDirty(System.String,System.String)" /> for side effects).
+             object as dirty (see <see cref="M:Microsoft.Build.ObjectModelRemoting.ProjectRootElementLink.MarkDirty(System.String,System.String)" /> for side effects).
             
              If the new state has invalid XML or MSBuild syntax, then this method throws an <see cref="T:Microsoft.Build.Exceptions.InvalidProjectFileException" />.
              When this happens, the state of this object does not change.

--- a/msbuild-api-docs/xml/Microsoft.Build.Framework.XamlTypes/BaseProperty.xml
+++ b/msbuild-api-docs/xml/Microsoft.Build.Framework.XamlTypes/BaseProperty.xml
@@ -512,7 +512,7 @@
             </summary>
         <value>The Help file to use when the user presses F1.</value>
         <remarks>
-            This property goes along with <see cref="P:Microsoft.Build.Framework.XamlTypes.BaseProperty.HelpContext" />. <seealso cref="P:Microsoft.Build.Framework.XamlTypes.BaseProperty.HelpContext" />. This
+            This property goes along with <see cref="P:Microsoft.Build.Framework.XamlTypes.BaseProperty.HelpContext" />. This
             form of specifying the help page for a property takes lower precedence than both <see cref="P:Microsoft.Build.Framework.XamlTypes.BaseProperty.F1Keyword" />
             and <see cref="P:Microsoft.Build.Framework.XamlTypes.BaseProperty.HelpUrl" />.
             This field is optional and is culture insensitive.

--- a/msbuild-api-docs/xml/Microsoft.Build.Framework/BuildEventArgs.xml
+++ b/msbuild-api-docs/xml/Microsoft.Build.Framework/BuildEventArgs.xml
@@ -306,7 +306,7 @@
       </ReturnValue>
       <Docs>
         <summary>
-            Exposes the private <see cref="F:Microsoft.Build.Framework.BuildEventArgs.timestamp" /> field to derived types.
+            Exposes the private Microsoft.Build.Framework.BuildEventArgs.timestamp field to derived types.
             Used for serialization. Avoids the side effects of calling the
             <see cref="P:Microsoft.Build.Framework.BuildEventArgs.Timestamp" /> getter.
             </summary>

--- a/msbuild-api-docs/xml/Microsoft.Build.Framework/CustomBuildEventArgs.xml
+++ b/msbuild-api-docs/xml/Microsoft.Build.Framework/CustomBuildEventArgs.xml
@@ -36,10 +36,10 @@
       <format type="text/markdown"><![CDATA[
             ## Remarks
             > [!CAUTION]
-            In .NET 8 and later and Visual Studio 17.8 and later, this type is deprecated; instead use <see cref="ExtendedCustomBuildEventArgs"/>.
-            For more information, see <see href="https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs"/>
-            For recommended replacement, see <see href="https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs#recommended-action" />.
-            ]]></format>
+            In .NET 8 and later and Visual Studio 17.8 and later, this type is deprecated; instead use <xref:Microsoft.Build.Framework.ExtendedCustomBuildEventArgs>.
+            For more information, see [this link](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs).
+            For recommended replacement, see [this link](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs#recommended-action).
+            ]]></format>       
     </remarks>
   </Docs>
   <Members>


### PR DESCRIPTION
Fix the warning from build https://github.com/dotnet/msbuild-api-docs/pull/39
[9766](https://github.com/dotnet/msbuild/issues/9766)

[msbuild-api-docs/xml/Microsoft.Build.Construction/ProjectRootElement.xml](https://github.com/dotnet/msbuild-api-docs/blob/smoke-test/msbuild-api-docs/xml/Microsoft.Build.Construction/ProjectRootElement.xml)
Line 0, Column 0: [Warning: xref-not-found - [See documentation](https://review.learn.microsoft.com/en-us/help/platform/validation-ref/xref-not-found?branch=main)] Cross reference not found: 'Microsoft.Build.Construction.ProjectRootElement.MarkDirty(System.String,System.String)'.

[msbuild-api-docs/xml/Microsoft.Build.Framework.XamlTypes/BaseProperty.xml](https://github.com/dotnet/msbuild-api-docs/blob/smoke-test/msbuild-api-docs/xml/Microsoft.Build.Framework.XamlTypes/BaseProperty.xml)
Line 0, Column 0: [Warning: disallowed-html-tag - [See documentation](https://review.learn.microsoft.com/help/contribute/validation-ref/disallowed-html-tag?branch=main)] HTML tag 'seealso' isn't allowed.  Replace it with approved Markdown or escape the brackets if the content is a placeholder.

[msbuild-api-docs/xml/Microsoft.Build.Framework/BuildEventArgs.xml](https://github.com/dotnet/msbuild-api-docs/blob/smoke-test/msbuild-api-docs/xml/Microsoft.Build.Framework/BuildEventArgs.xml)
Line 0, Column 0: [Warning: xref-not-found - [See documentation](https://review.learn.microsoft.com/en-us/help/platform/validation-ref/xref-not-found?branch=main)] Cross reference not found: 'Microsoft.Build.Framework.BuildEventArgs.timestamp'.

[msbuild-api-docs/xml/Microsoft.Build.Framework/CustomBuildEventArgs.xml](https://github.com/dotnet/msbuild-api-docs/blob/smoke-test/msbuild-api-docs/xml/Microsoft.Build.Framework/CustomBuildEventArgs.xml)
Line 0, Column 0: [Warning: disallowed-html-tag - [See documentation](https://review.learn.microsoft.com/help/contribute/validation-ref/disallowed-html-tag?branch=main)] HTML tag 'see' isn't allowed.  Replace it with approved Markdown or escape the brackets if the content is a placeholder.
Line 0, Column 0: [Warning: disallowed-html-tag - [See documentation](https://review.learn.microsoft.com/help/contribute/validation-ref/disallowed-html-tag?branch=main)] HTML tag 'see' isn't allowed.  Replace it with approved Markdown or escape the brackets if the content is a placeholder.
Line 0, Column 0: [Warning: disallowed-html-tag - [See documentation](https://review.learn.microsoft.com/help/contribute/validation-ref/disallowed-html-tag?branch=main)] HTML tag 'see' isn't allowed.  Replace it with approved Markdown or escape the brackets if the content is a placeholder.