### PR TITLE
Update remarks for thread safety in TaskLoggingHelper

### DIFF
--- a/msbuild-api-docs/xml/Microsoft.Build.Utilities/TaskLoggingHelper.xml
+++ b/msbuild-api-docs/xml/Microsoft.Build.Utilities/TaskLoggingHelper.xml
@@ -606,9 +606,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
-## Remarks  
- This method is not thread-safe.  
-  
  ]]></format>
         </remarks>
       </Docs>


### PR DESCRIPTION
Removed thread-safety note from remarks section, it's not consistent with the content of the page.